### PR TITLE
Zwei Sekunden delay nach mp3.begin() eingefügt.

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -385,6 +385,8 @@ void setup() {
 
   // DFPlayer Mini initialisieren
   mp3.begin();
+  // Zwei Sekunden warten bis der DFPlayer Mini initialisiert ist
+  delay(2000);
   volume = mySettings.initVolume;
   mp3.setVolume(volume);
   mp3.setEq(mySettings.eq - 1);


### PR DESCRIPTION
Der DFPlayer Mini benötigt einige Zeit nach `mp3.begin()` um auf weitere Befehle zu reagieren. Dadurch wurde in unserem Fall die initiale Lautstärke (wiederhergestellt aus dem EEPROM) nicht korrekt vom DFPlayer Mini übernommen. Ein kleiner delay behebt das Problem erstmal.