### PR TITLE
ändert KEY_B zu KEY_A

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -1172,9 +1172,9 @@ void writeCard(nfcTagObject nfcTag) {
       (mifareType == MFRC522::PICC_TYPE_MIFARE_1K ) ||
       (mifareType == MFRC522::PICC_TYPE_MIFARE_4K ) )
   {
-    Serial.println(F("Authenticating again using key B..."));
+    Serial.println(F("Authenticating again using key A..."));
     status = mfrc522.PCD_Authenticate(
-               MFRC522::PICC_CMD_MF_AUTH_KEY_B, trailerBlock, &key, &(mfrc522.uid));
+               MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
   }
   else if (mifareType == MFRC522::PICC_TYPE_MIFARE_UL )
   {


### PR DESCRIPTION
Es kommt immer wieder vor, dass Nutzer Probleme mit KEY_B haben. Lösung war bisher immer auf KEY_A zu wechseln. Den umgekehrten Fall gab es bisher nie. Daher würde ich sagen wir wechseln dauerhaft auf KEY_A.