### PR TITLE
fixt build error wegen DFMiniMp3 library update auf 1.0.3

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -105,6 +105,15 @@ class Mp3Notify {
     static void OnCardRemoved(uint16_t code) {
       Serial.println(F("SD Karte entfernt "));
     }
+    static void OnUsbOnline(uint16_t code) {
+      Serial.println(F("USB online "));
+    }
+    static void OnUsbInserted(uint16_t code) {
+      Serial.println(F("USB bereit "));
+    }
+    static void OnUsbRemoved(uint16_t code) {
+      Serial.println(F("USB entfernt "));
+    }
 };
 
 static DFMiniMp3<SoftwareSerial, Mp3Notify> mp3(mySoftwareSerial);


### PR DESCRIPTION
Momentan baut keine FW mehr mit der 1.0.3 der Library weil in der `class Mp3Notify` drei Einträge für USB fehlen:

    +    static void OnUsbOnline(uint16_t code) {
    +      Serial.println(F("USB online "));
    +    }
    +    static void OnUsbInserted(uint16_t code) {
    +      Serial.println(F("USB bereit "));
    +    }
    +    static void OnUsbRemoved(uint16_t code) {
    +      Serial.println(F("USB entfernt "));
    +    }