### PR TITLE
Add PlatformIO and Visual Studio Code specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,12 @@ Temporary Items
 
 # TonUINO
 /tools/*.pyc
+
+# PlatformIO folders and files
+.pio
+.vscode
+include
+lib
+src
+test
+platformio.ini


### PR DESCRIPTION
This PR adds PlatformIO and Visual Studio Code specific files and folders to `.gitignore` so that VS Code can be used by developers alongside Arduino IDE without interference.