### PR TITLE
Added new "single track" modifier, fixed bug in dealing with duplicate OnPlayFinished events

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -277,12 +277,14 @@ class SleepTimer: public Modifier {
 
     SleepTimer(uint8_t minutes) {
       Serial.println(F("=== SleepTimer()"));
-      Serial.println(minutes);
+      Serial.print(minutes);
+      Serial.println(F(" minutes"));
       this->sleepAtMillis = millis() + minutes * 60000;
       //      if (isPlaying())
       //        mp3.playAdvertisement(302);
       //      delay(500);
     }
+    
     uint8_t getActive() {
       Serial.println(F("== SleepTimer::getActive()"));
       return 1;
@@ -298,7 +300,8 @@ class FreezeDance: public Modifier {
     void setNextStopAtMillis() {
       uint16_t seconds = random(this->minSecondsBetweenStops, this->maxSecondsBetweenStops + 1);
       Serial.println(F("=== FreezeDance::setNextStopAtMillis()"));
-      Serial.println(seconds);
+      Serial.print(seconds);
+      Serial.println(F(" seconds"));
       this->nextStopAtMillis = millis() + seconds * 1000;
     }
 
@@ -313,6 +316,7 @@ class FreezeDance: public Modifier {
         setNextStopAtMillis();
       }
     }
+    
     FreezeDance(void) {
       Serial.println(F("=== FreezeDance()"));
       if (isPlaying()) {
@@ -322,6 +326,7 @@ class FreezeDance: public Modifier {
       }
       setNextStopAtMillis();
     }
+    
     uint8_t getActive() {
       Serial.println(F("== FreezeDance::getActive()"));
       return 2;
@@ -419,18 +424,22 @@ class KindergardenMode: public Modifier {
       }
       return false;
     }
+    
     //    virtual bool handlePause()     {
     //      Serial.println(F("== KindergardenMode::handlePause() -> LOCKED!"));
     //      return true;
     //    }
+    
     virtual bool handleNextButton()       {
       Serial.println(F("== KindergardenMode::handleNextButton() -> LOCKED!"));
       return true;
     }
+    
     virtual bool handlePreviousButton() {
       Serial.println(F("== KindergardenMode::handlePreviousButton() -> LOCKED!"));
       return true;
     }
+    
     virtual bool handleRFID(nfcTagObject * newCard) { // lot of work to do!
       Serial.println(F("== KindergardenMode::handleRFID() -> queued!"));
       this->nextCard = *newCard;
@@ -440,12 +449,14 @@ class KindergardenMode: public Modifier {
       }
       return true;
     }
+    
     KindergardenMode() {
       Serial.println(F("=== KindergardenMode()"));
       //      if (isPlaying())
       //        mp3.playAdvertisement(305);
       //      delay(500);
     }
+    
     uint8_t getActive() {
       Serial.println(F("== KindergardenMode::getActive()"));
       return 5;
@@ -462,9 +473,11 @@ class RepeatSingleModifier: public Modifier {
       _lastTrackFinished = 0;
       return true;
     }
+    
     RepeatSingleModifier() {
       Serial.println(F("=== RepeatSingleModifier()"));
     }
+    
     uint8_t getActive() {
       Serial.println(F("== RepeatSingleModifier::getActive()"));
       return 6;
@@ -488,6 +501,7 @@ class FeedbackModifier: public Modifier {
       Serial.println(F("== FeedbackModifier::handleVolumeDown()!"));
       return false;
     }
+    
     virtual bool handleVolumeUp() {
       if (volume < mySettings.maxVolume) {
         mp3.playAdvertisement(volume + 1);
@@ -499,6 +513,7 @@ class FeedbackModifier: public Modifier {
       Serial.println(F("== FeedbackModifier::handleVolumeUp()!"));
       return false;
     }
+    
     virtual bool handleRFID(nfcTagObject *newCard) {
       Serial.println(F("== FeedbackModifier::handleRFID()"));
       return false;
@@ -507,6 +522,8 @@ class FeedbackModifier: public Modifier {
 
 // Leider kann das Modul selbst keine Queue abspielen, daher müssen wir selbst die Queue verwalten
 static void nextTrack(uint16_t track) {
+  Serial.println(F("=== nextTrack()"));
+  Serial.print(F("Finished track "));
   Serial.println(track);
   if (activeModifier != NULL)
     if (activeModifier->handleNext() == true)
@@ -522,8 +539,6 @@ static void nextTrack(uint16_t track) {
     // verarbeitet werden
     return;
 
-  Serial.println(F("=== nextTrack()"));
-
   if (myFolder->mode == 1 || myFolder->mode == 7) {
     Serial.println(F("Hörspielmodus ist aktiv -> keinen neuen Track spielen"));
     setstandbyTimer();
@@ -534,15 +549,15 @@ static void nextTrack(uint16_t track) {
       currentTrack = currentTrack + 1;
       mp3.playFolderTrack(myFolder->folder, currentTrack);
       Serial.print(F("Albummodus ist aktiv -> nächster Track: "));
-      Serial.print(currentTrack);
-    } else
+      Serial.println(currentTrack);
+    } else {
       //      mp3.sleep();   // Je nach Modul kommt es nicht mehr zurück aus dem Sleep!
       setstandbyTimer();
-    { }
+    }
   }
   if (myFolder->mode == 3 || myFolder->mode == 9) {
     if (currentTrack != numTracksInFolder - firstTrack + 1) {
-      Serial.print(F("Party -> weiter in der Queue "));
+      Serial.println(F("Party -> weiter in der Queue "));
       currentTrack++;
     } else {
       Serial.println(F("Ende der Queue -> beginne von vorne"));
@@ -551,6 +566,7 @@ static void nextTrack(uint16_t track) {
       //     Serial.println(F("Ende der Queue -> mische neu"));
       //     shuffleQueue();
     }
+    Serial.print(F("Next track from queue is "));
     Serial.println(queue[currentTrack - 1]);
     mp3.playFolderTrack(myFolder->folder, queue[currentTrack - 1]);
   }
@@ -563,8 +579,8 @@ static void nextTrack(uint16_t track) {
   if (myFolder->mode == 5) {
     if (currentTrack != numTracksInFolder) {
       currentTrack = currentTrack + 1;
-      Serial.print(F("Hörbuch Modus ist aktiv -> nächster Track und "
-                     "Fortschritt speichern"));
+      Serial.println(F("Hörbuch Modus ist aktiv -> nächster Track und Fortschritt speichern"));
+      Serial.print(F("Next track is "));
       Serial.println(currentTrack);
       mp3.playFolderTrack(myFolder->folder, currentTrack);
       // Fortschritt im EEPROM abspeichern
@@ -594,14 +610,15 @@ static void previousTrack() {
   }
   if (myFolder->mode == 3 || myFolder->mode == 9) {
     if (currentTrack != 1) {
-      Serial.print(F("Party Modus ist aktiv -> zurück in der Qeueue "));
+      Serial.println(F("Party Modus ist aktiv -> zurück in der Qeueue "));
       currentTrack--;
     }
     else
     {
-      Serial.print(F("Anfang der Queue -> springe ans Ende "));
+      Serial.println(F("Anfang der Queue -> springe ans Ende "));
       currentTrack = numTracksInFolder;
     }
+    Serial.print(F("Previous track from queue is "));
     Serial.println(queue[currentTrack - 1]);
     mp3.playFolderTrack(myFolder->folder, queue[currentTrack - 1]);
   }
@@ -610,11 +627,12 @@ static void previousTrack() {
     mp3.playFolderTrack(myFolder->folder, currentTrack);
   }
   if (myFolder->mode == 5) {
-    Serial.println(F("Hörbuch Modus ist aktiv -> vorheriger Track und "
-                     "Fortschritt speichern"));
+    Serial.println(F("Hörbuch Modus ist aktiv -> vorheriger Track und Fortschritt speichern"));
     if (currentTrack != 1) {
       currentTrack = currentTrack - 1;
     }
+    Serial.print(F("Previous track is "));
+    Serial.println(currentTrack);
     mp3.playFolderTrack(myFolder->folder, currentTrack);
     // Fortschritt im EEPROM abspeichern
     EEPROM.update(myFolder->folder, currentTrack);
@@ -670,7 +688,9 @@ void setstandbyTimer() {
     sleepAtMillis = millis() + (mySettings.standbyTimer * 60 * 1000);
   else
     sleepAtMillis = 0;
-  Serial.println(sleepAtMillis);
+  Serial.print(F("Standby timer set to "));
+  Serial.print(sleepAtMillis);
+  Serial.println(F(" millis"));
 }
 
 void disablestandbyTimer() {
@@ -809,6 +829,7 @@ void volumeUpButton() {
     mp3.increaseVolume();
     volume++;
   }
+  Serial.print(F("Volume "));
   Serial.println(volume);
 }
 
@@ -822,6 +843,7 @@ void volumeDownButton() {
     mp3.decreaseVolume();
     volume--;
   }
+  Serial.print(F("Volume "));
   Serial.println(volume);
 }
 
@@ -858,6 +880,7 @@ void playFolder() {
   if (myFolder->mode == 1) {
     Serial.println(F("Hörspielmodus -> zufälligen Track wiedergeben"));
     currentTrack = random(1, numTracksInFolder + 1);
+    Serial.print(F("Playing track "));
     Serial.println(currentTrack);
     mp3.playFolderTrack(myFolder->folder, currentTrack);
   }
@@ -869,37 +892,37 @@ void playFolder() {
   }
   // Party Modus: Ordner in zufälliger Reihenfolge
   if (myFolder->mode == 3) {
-    Serial.println(
-      F("Party Modus -> Ordner in zufälliger Reihenfolge wiedergeben"));
+    Serial.println(F("Party Modus -> Ordner in zufälliger Reihenfolge wiedergeben"));
     shuffleQueue();
     currentTrack = 1;
     mp3.playFolderTrack(myFolder->folder, queue[currentTrack - 1]);
   }
   // Einzel Modus: eine Datei aus dem Ordner abspielen
   if (myFolder->mode == 4) {
-    Serial.println(
-      F("Einzel Modus -> eine Datei aus dem Odrdner abspielen"));
+    Serial.println(F("Einzel Modus -> eine Datei aus dem Odrdner abspielen"));
     currentTrack = myFolder->special;
     mp3.playFolderTrack(myFolder->folder, currentTrack);
   }
   // Hörbuch Modus: kompletten Ordner spielen und Fortschritt merken
   if (myFolder->mode == 5) {
-    Serial.println(F("Hörbuch Modus -> kompletten Ordner spielen und "
-                     "Fortschritt merken"));
+    Serial.println(F("Hörbuch Modus -> kompletten Ordner spielen und Fortschritt merken"));
     currentTrack = EEPROM.read(myFolder->folder);
     if (currentTrack == 0 || currentTrack > numTracksInFolder) {
       currentTrack = 1;
     }
+    Serial.print(F("Playing track "));
+    Serial.println(currentTrack);
     mp3.playFolderTrack(myFolder->folder, currentTrack);
   }
-  // Spezialmodus Von-Bin: Hörspiel: eine zufällige Datei aus dem Ordner
+  // Spezialmodus Von-Bis: Hörspiel: eine zufällige Datei aus dem Ordner
   if (myFolder->mode == 7) {
-    Serial.println(F("Spezialmodus Von-Bin: Hörspiel -> zufälligen Track wiedergeben"));
+    Serial.println(F("Spezialmodus Von-Bis: Hörspiel -> zufälligen Track wiedergeben"));
     Serial.print(myFolder->special);
     Serial.print(F(" bis "));
     Serial.println(myFolder->special2);
     numTracksInFolder = myFolder->special2;
     currentTrack = random(myFolder->special, numTracksInFolder + 1);
+    Serial.print(F("Playing track "));
     Serial.println(currentTrack);
     mp3.playFolderTrack(myFolder->folder, currentTrack);
   }
@@ -917,8 +940,7 @@ void playFolder() {
 
   // Spezialmodus Von-Bis: Party Ordner in zufälliger Reihenfolge
   if (myFolder->mode == 9) {
-    Serial.println(
-      F("Spezialmodus Von-Bis: Party -> Ordner in zufälliger Reihenfolge wiedergeben"));
+    Serial.println(F("Spezialmodus Von-Bis: Party -> Ordner in zufälliger Reihenfolge wiedergeben"));
     firstTrack = myFolder->special;
     numTracksInFolder = myFolder->special2;
     shuffleQueue();
@@ -929,6 +951,7 @@ void playFolder() {
 
 void playShortCut(uint8_t shortCut) {
   Serial.println(F("=== playShortCut()"));
+  Serial.print(F("Selected shortcut "));
   Serial.println(shortCut);
   if (mySettings.shortCuts[shortCut].folder != 0) {
     myFolder = &mySettings.shortCuts[shortCut];
@@ -1154,6 +1177,7 @@ void adminMenu(bool fromCard = false) {
       }
       waitForTrackToFinish();
       mp3.playMp3FolderTrack(b);
+      Serial.print(F("C is "));
       Serial.println(c);
       uint8_t temp = voiceMenu(255, 0, 0, false);
       if (temp != c) {
@@ -1363,9 +1387,8 @@ uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
     }
     if (pauseButton.wasReleased()) {
       if (returnValue != 0) {
-        Serial.print(F("=== "));
-        Serial.print(returnValue);
-        Serial.println(F(" ==="));
+        Serial.print(F("Selected option "));
+        Serial.println(returnValue);
         return returnValue;
       }
       delay(1000);
@@ -1373,6 +1396,7 @@ uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
 
     if (upButton.pressedFor(LONG_PRESS)) {
       returnValue = min(returnValue + 10, numberOfOptions);
+      Serial.print(F("Current option "));
       Serial.println(returnValue);
       //mp3.pause();
       mp3.playMp3FolderTrack(messageOffset + returnValue);
@@ -1387,6 +1411,7 @@ uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
     } else if (upButton.wasReleased()) {
       if (!ignoreUpButton) {
         returnValue = min(returnValue + 1, numberOfOptions);
+        Serial.print(F("Current option "));
         Serial.println(returnValue);
         //mp3.pause();
         mp3.playMp3FolderTrack(messageOffset + returnValue);
@@ -1406,6 +1431,7 @@ uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
 
     if (downButton.pressedFor(LONG_PRESS)) {
       returnValue = max(returnValue - 10, 1);
+      Serial.print(F("Current option "));
       Serial.println(returnValue);
       //mp3.pause();
       mp3.playMp3FolderTrack(messageOffset + returnValue);
@@ -1420,6 +1446,7 @@ uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
     } else if (downButton.wasReleased()) {
       if (!ignoreDownButton) {
         returnValue = max(returnValue - 1, 1);
+        Serial.print(F("Current option "));
         Serial.println(returnValue);
         //mp3.pause();
         mp3.playMp3FolderTrack(messageOffset + returnValue);
@@ -1602,10 +1629,8 @@ bool readCard(nfcTagObject * nfcTag) {
     memcpy(buffer + 12, buffer2, 4);
   }
 
-  Serial.print(F("Data on Card "));
-  Serial.println(F(":"));
+  Serial.println(F("Data on Card:"));
   dump_byte_array(buffer, 16);
-  Serial.println();
   Serial.println();
 
   uint32_t tempCookie;
@@ -1677,8 +1702,8 @@ bool readCard(nfcTagObject * nfcTag) {
     }
     else {
       memcpy(nfcTag, &tempCard, sizeof(nfcTagObject));
-      Serial.println( nfcTag->nfcFolderSettings.folder);
       myFolder = &nfcTag->nfcFolderSettings;
+      Serial.print(F("Folder "));
       Serial.println( myFolder->folder);
     }
     return true;
@@ -1774,7 +1799,6 @@ void writeCard(nfcTagObject nfcTag) {
   }
   else
     mp3.playMp3FolderTrack(400);
-  Serial.println();
   delay(2000);
 }
 

--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -20,6 +20,9 @@
 // uncomment the below line to enable five button support
 //#define FIVEBUTTONS
 
+// uncomment the below line to enable a power led (by default at pin D5)
+//#define POWERLED
+
 static const uint32_t cardCookie = 322417479;
 
 // DFPlayer Mini
@@ -738,6 +741,10 @@ MFRC522::StatusCode status;
 #define buttonFivePin A4
 #endif
 
+#ifdef POWERLED
+#define powerLedPin 5
+#endif
+
 #define LONG_PRESS 1000
 
 Button pauseButton(buttonPause);
@@ -776,6 +783,9 @@ void disablestandbyTimer() {
 void checkStandbyAtMillis() {
   if (sleepAtMillis != 0 && millis() > sleepAtMillis) {
     Serial.println(F("=== power off!"));
+#ifdef POWERLED
+    digitalWrite(powerLedPin, LOW);
+#endif
     // enter sleep state
     digitalWrite(shutdownPin, HIGH);
     delay(500);
@@ -809,6 +819,10 @@ void waitForTrackToFinish() {
 }
 
 void setup() {
+#ifdef POWERLED
+  pinMode(powerLedPin, OUTPUT);
+  digitalWrite(powerLedPin, HIGH);
+#endif
 
   Serial.begin(115200); // Es gibt ein paar Debug Ausgaben über die serielle Schnittstelle
 

--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -70,7 +70,7 @@ folderSettings *myFolder;
 unsigned long sleepAtMillis = 0;
 static uint16_t _lastTrackFinished;
 
-static void nextTrack(uint16_t track);
+static void nextTrack();
 uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
                   bool preview = false, int previewFromFolder = 0, int defaultValue = 0, bool exitWithLongPress = false);
 bool isPlaying();
@@ -98,11 +98,17 @@ class Mp3Notify {
       Serial.println(action);
     }
     static void OnPlayFinished(DfMp3_PlaySources source, uint16_t track) {
-      //      Serial.print("Track beendet");
-      //      Serial.println(track);
-      //      delay(100);
-      nextTrack(track);
+      Serial.println(track);
+      //delay(100);
+      if (track == _lastTrackFinished) {
+        Serial.println(F("Ignoring duplicate OnPlayFinished event"));
+        return;
+      }
+      _lastTrackFinished = track;
+      
+      nextTrack();
     }
+
     static void OnPlaySourceOnline(DfMp3_PlaySources source) {
       PrintlnSourceAction(source, "online");
     }
@@ -589,18 +595,12 @@ class FeedbackModifier: public Modifier {
 };
 
 // Leider kann das Modul selbst keine Queue abspielen, daher müssen wir selbst die Queue verwalten
-static void nextTrack(uint16_t track) {
+static void nextTrack() {
   Serial.println(F("=== nextTrack()"));
-  Serial.print(F("Finished track "));
-  Serial.println(track);
+
   if (activeModifier != NULL)
     if (activeModifier->handleNext() == true)
       return;
-
-  if (track == _lastTrackFinished) {
-    return;
-  }
-  _lastTrackFinished = track;
 
   if (knownCard == false)
     // Wenn eine neue Karte angelernt wird soll das Ende eines Tracks nicht
@@ -927,7 +927,7 @@ void nextButton() {
     if (activeModifier->handleNextButton() == true)
       return;
 
-  nextTrack(random(65536));
+  nextTrack();
   delay(1000);
 }
 

--- a/audio_messages_de.txt
+++ b/audio_messages_de.txt
@@ -73,6 +73,7 @@ mp3/0973_modifier_Locked.mp3|TonUINO Sperren
 mp3/0974_modifier_Toddler.mp3|Krabbler-Modus - Alle Tasten vom TonUINO werden für die ganz Kleinen gesperrt. Karten funktionieren weiterhin.
 mp3/0975_modifier_KinderGarden.mp3|KiTa-Modus - Damit es keinen Streit mehr gibt werden neue Karten nicht sofort gespielt sondern erst nachdem das aktuelle Lied vorbei ist. Die Vor- und Zurücktasten sind gesperrt.
 mp3/0976_modifier_repeat1.mp3|Titel wiederholen - den aktuellen Titel endlos wiederholen.
+mp3/0977_modifier_single_track.mp3|Einzelmodus - Der aktuelle Titel wird wiedergegeben, danach endet die Wiedergabe.
 mp3/0980_admin_lock_intro.mp3|Wähle bitte aus ob und wie das Adminmenü geschützt werden soll.
 mp3/0981_admin_lock_disabled.mp3|Kein Schutz - das Adminmenü kann jederzeit durch drücken von allen drei Tasten aktiviert werden.
 mp3/0982_admin_lock_card.mp3|Nur Adminkarte - das Adminmenü kann nur mit einer Adminkarte geöffnet werden. Eine neue Adminkarte kann jederzeit angelernt werden.


### PR DESCRIPTION
The new modifier stops playing after the current track has ended, no matter what mode is configured and how many tracks may be left in the folder.
The bug in handling duplicate OnPlayFinished events caused that handleNext methods from modifiers were called multiple times.
Apart from that, I improved logging and introduced mode and modifiers enums to make the code easier to understand for new developers - and to get a grasp of what is going on myself. With the plain integer numbers that were used previously I found itsometimes confusing because it's not directly visible if the number encodes a mode or  a modifier.
