### PR TITLE
Implement VolumeLimiter

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -471,6 +471,29 @@ class RepeatSingleModifier: public Modifier {
     }
 };
 
+class VolumeLimiter: public Modifier {
+  private:
+    uint8_t maxVolume;
+
+  public:
+    VolumeLimiter(uint8_t maxVolume) {
+      Serial.println("Volume limiter active");
+      Serial.print("Max Volume: ");
+      Serial.println(maxVolume);
+      this->maxVolume = maxVolume;
+      volume = mySettings.minVolume;
+      delay(500);
+      mp3.setVolume(volume);
+    }
+
+    virtual bool handleVolumeUp() {
+      return (volume >= maxVolume);
+    }
+    virtual uint8_t getActive() {
+      return 7;
+    }
+};
+
 // An modifier can also do somethings in addition to the modified action
 // by returning false (not handled) at the end
 // This simple FeedbackModifier will tell the volume before changing it and
@@ -1671,6 +1694,7 @@ bool readCard(nfcTagObject * nfcTag) {
         case 4: activeModifier = new ToddlerMode(); break;
         case 5: activeModifier = new KindergardenMode(); break;
         case 6: activeModifier = new RepeatSingleModifier(); break;
+        case 7: activeModifier = new VolumeLimiter(tempCard.nfcFolderSettings.special); break;
 
       }
       delay(2000);


### PR DESCRIPTION
This implements a modifier acting as a temporary volume limiter. The temporary maximum volume is taken from the first extra field of the NFC card.