### PR TITLE
Fixed bug 76: handleNext method of active modifier is not called twice anymore if a duplicate OnPlayFinished event is received

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -70,7 +70,7 @@ folderSettings *myFolder;
 unsigned long sleepAtMillis = 0;
 static uint16_t _lastTrackFinished;
 
-static void nextTrack(uint16_t track);
+static void nextTrack();
 uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
                   bool preview = false, int previewFromFolder = 0, int defaultValue = 0, bool exitWithLongPress = false);
 bool isPlaying();
@@ -98,10 +98,16 @@ class Mp3Notify {
       Serial.println(action);
     }
     static void OnPlayFinished(DfMp3_PlaySources source, uint16_t track) {
-      //      Serial.print("Track beendet");
-      //      Serial.println(track);
+      Serial.print("Track beendet ");
+      Serial.println(track);
       //      delay(100);
-      nextTrack(track);
+      if (track == _lastTrackFinished) {
+        Serial.println(F("Ignoring duplicate OnPlayFinished event"));
+        return;
+      }
+
+      _lastTrackFinished = track;
+      nextTrack();
     }
     static void OnPlaySourceOnline(DfMp3_PlaySources source) {
       PrintlnSourceAction(source, "online");
@@ -511,16 +517,10 @@ class FeedbackModifier: public Modifier {
 };
 
 // Leider kann das Modul selbst keine Queue abspielen, daher müssen wir selbst die Queue verwalten
-static void nextTrack(uint16_t track) {
-  Serial.println(track);
+static void nextTrack() {
   if (activeModifier != NULL)
     if (activeModifier->handleNext() == true)
       return;
-
-  if (track == _lastTrackFinished) {
-    return;
-  }
-  _lastTrackFinished = track;
 
   if (knownCard == false)
     // Wenn eine neue Karte angelernt wird soll das Ende eines Tracks nicht
@@ -835,7 +835,7 @@ void nextButton() {
     if (activeModifier->handleNextButton() == true)
       return;
 
-  nextTrack(random(65536));
+  nextTrack();
   delay(1000);
 }
 


### PR DESCRIPTION
This fixes issue #76. The check whether the ended track is similar to the last ended track was moved into the OnPlayFinished method. This has the additinal benefit, that no tack number is required as input for nextTrack. So we don't have to come up with a random one if the next button is pressed.