### PR TITLE
Automatische Abschaltung und wieder Aufwachen für Powerbanks ohne Standby-Mode

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -266,7 +266,7 @@ class SleepTimer: public Modifier {
 
   public:
     void loop() {
-      if (this->sleepAtMillis != 0 && millis() > this->sleepAtMillis) {
+      if (this->sleepAtMillis != 0 && (int)(millis() - this->sleepAtMillis) >= 0) {
         Serial.println(F("=== SleepTimer::loop() -> SLEEP!"));
         mp3.pause();
         setstandbyTimer();
@@ -304,7 +304,7 @@ class FreezeDance: public Modifier {
 
   public:
     void loop() {
-      if (this->nextStopAtMillis != 0 && millis() > this->nextStopAtMillis) {
+      if (this->nextStopAtMillis != 0 && (int)(millis() - this->nextStopAtMillis) >= 0 ) {
         Serial.println(F("== FreezeDance::loop() -> FREEZE!"));
         if (isPlaying()) {
           mp3.playAdvertisement(301);
@@ -684,7 +684,7 @@ void disablestandbyTimer() {
 }
 
 void checkStandbyAtMillis() {
-  if (sleepAtMillis != 0 && millis() > sleepAtMillis) {
+  if (sleepAtMillis != 0 && (int)(millis() - sleepAtMillis) >= 0) {
     Serial.println(F("=== power off!"));
     // enter sleep state
     digitalWrite(shutdownPin, HIGH);


### PR DESCRIPTION
Ich habe hier einen Vorschlag zum leidigen Abschaltproblem.

Bisher schaltet der Standby-Mode die CPU ab und wartet darauf, dass die Powerbank ihr den Saft abdreht. Aufwachen ist nicht vorgesehen, es wird erwartet, dass die Spannungs später wieder von extern angelegt wird und das System komplett neu startet. Das funktioniert mit meiner Powerbank nicht zuverlässig. Mittlerweile habe ich eine komplette rundum-glücklich-Platine mit Akku, Akkuschutz, Ladeelektronik, Spannungswandler, CPU, USB/Ladeanschluss und den üblichen Steckkontakten für die Tasten und die Module entworfen.

Meine Lösung hat keinen Standby-Modus der Batterie. Stattdessen schaltet die CPU über einen einfachen PMOS oder PNP-Transistor die Spannungsversorgung für das MP3- und das RF-ID-Modul ab und geht in den power down modus. Jetzt ist der Stromverbrauch von ca. 500uA vernachlässigbar.
Zum Aufwachen wird eine Einschalt-Taste, die am Interrupt-Eingang D2/INT0 hängt, kurz gedrückt und die CPU wacht wieder auf.

Die Änderungen an der Firmware sollten mit den anderen Abschaltlösungen (insbes. Pololu) kompatibel sein. Nur der Zeitpunkt verschiebt sich minimal.
