### PR TITLE
Entferne Warnungen beim Kompilieren

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -1114,7 +1114,7 @@ void loop() {
   mfrc522.PCD_StopCrypto1();
 }
 
-void adminMenu(bool fromCard = false) {
+void adminMenu(bool fromCard) {
   disablestandbyTimer();
   mp3.pause();
   Serial.println(F("=== adminMenu()"));
@@ -1346,7 +1346,7 @@ bool askCode(uint8_t *code) {
 }
 
 uint8_t voiceMenu(int numberOfOptions, int startMessage, int messageOffset,
-                  bool preview = false, int previewFromFolder = 0, int defaultValue = 0, bool exitWithLongPress = false) {
+                  bool preview, int previewFromFolder, int defaultValue, bool exitWithLongPress) {
   uint8_t returnValue = defaultValue;
   if (startMessage != 0)
     mp3.playMp3FolderTrack(startMessage);

--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -1313,7 +1313,7 @@ void adminMenu(bool fromCard) {
       mySettings.adminMenuLocked = 1;
     }
     else if (temp == 3) {
-      int8_t pin[4];
+      uint8_t pin[4];
       mp3.playMp3FolderTrack(991);
       if (askCode(pin)) {
         memcpy(mySettings.adminMenuPin, pin, 4);

--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -755,7 +755,7 @@ void setup() {
   delay(2000);
   volume = mySettings.initVolume;
   mp3.setVolume(volume);
-  mp3.setEq(mySettings.eq - 1);
+  mp3.setEq((DfMp3_Eq)(mySettings.eq - 1));
   // Fix für das Problem mit dem Timeout (ist jetzt in Upstream daher nicht mehr nötig!)
   //mySoftwareSerial.setTimeout(10000);
 
@@ -1189,7 +1189,7 @@ void adminMenu(bool fromCard = false) {
   else if (subMenu == 5) {
     // EQ
     mySettings.eq = voiceMenu(6, 920, 920, false, false, mySettings.eq);
-    mp3.setEq(mySettings.eq - 1);
+    mp3.setEq((DfMp3_Eq)(mySettings.eq - 1));
   }
   else if (subMenu == 6) {
     // create modifier card


### PR DESCRIPTION
Beim Kompilieren der TonUINO Firmware werden einige Warnungen angezeigt. Diese Warnungen sind sowohl für Anfänger:innen als auch für Fortgeschrittene störend. Anfänger:innen die nur die Firmware auf ihren TonUINO spielen wollen werden irritiert weil sie nicht einschätzen können ob diese Warnungen echte Probleme bedeuten. Für Entwickler:innen der Software stören die Warnungen, weil andere Fehlermeldungen oder neue Warnungen leicht übersehen werden können.

Außerdem deuten Warnungen auch auf potentielle Fehler hin. Es ist also auf jeden Fall sinnvoll die Warnungen soweit wie möglich zu beseitigen.

In diesem Branch sind alle `default` Warnungen behoben. Dadurch sehen unerfahrene Nutzer:innen, die nur schnell die Firmware für ihren TonUINO wollen, lediglich die Erfolgsmeldung der IDE und Entwickler:innen können sich auf die Fehler und Warnungen die ihre momentane Arbeit betreffen konzentrieren.

Details zu jeder Warnung sind in den jeweiligen Commits beschrieben. Es wurde nur das jeweils nötigste getan um die Warnung nicht mehr anzeigen zu lassen.