### PR TITLE
Bugfix für #95

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -605,7 +605,7 @@ static void previousTrack() {
     else
     {
       Serial.print(F("Anfang der Queue -> springe ans Ende "));
-      currentTrack = numTracksInFolder;
+      currentTrack = numTracksInFolder - firstTrack + 1;
     }
     Serial.println(queue[currentTrack - 1]);
     mp3.playFolderTrack(myFolder->folder, queue[currentTrack - 1]);


### PR DESCRIPTION
Spielt man etwas im Partymodus von-bis und der special-Wert (von) ist nicht 1, gibt es einen Fehler beim Zurückspulen. Sobald man das vordere Ende der Queue erreicht, schlägt das Track zurück fehl. Hier wird currentTrack auf special2 gesetzt. Die Queue geht allerdings nur von 1 bis special2 - special + 1. Deshalb wird eine 0 übergeben und nichts abgespielt.
Mit diesem Fix wird der letzte Track der Queue übergeben und nicht die Nummer des Tracks verwendet.