### PR TITLE
Bugfix #37

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -916,7 +916,8 @@ void playFolder() {
     Serial.print(F(" bis "));
     Serial.println(myFolder->special2);
     numTracksInFolder = myFolder->special2;
-    currentTrack = myFolder->special;
+    firstTrack = myFolder->special;
+    currentTrack = firstTrack;
     mp3.playFolderTrack(myFolder->folder, currentTrack);
   }
 


### PR DESCRIPTION
firstTrack wird auf special (von) gesetzt, damit vom Starttrack nicht zurück in ein anderes Album gespult werden kann.