### PR TITLE
Verwendung von VS Code mit Platformio Konfigurationsdatei

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# Platform.io and Visual Studio Code folders
+.pio/
+.vscode/
+
 # TonUINO
 /tools/*.pyc

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,21 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = $PROJECT_DIR
+
+[env:arduino]
+platform = atmelavr
+framework = arduino
+board = nanoatmega328
+lib_deps = 
+	miguelbalboa/MFRC522@^1.4.9
+	jchristensen/JC_Button@^2.1.2
+	makuna/DFPlayer Mini Mp3 by Makuna@1.0.7


### PR DESCRIPTION
Eine platformio.ini Datei, damit das Projekt mit VS Code gebaut werden kann. Die Bibliotheken sind dort angegeben, und man muss die dadurch nicht manuell hinzufügen. "DFPlayer Mini Mp3 by Makuna" musste ich auf genaue Version 1.0.7 setzen, damit es funktioniert. Andere stehen auf neuster Version oder höhere kompatible Version. 